### PR TITLE
Use underscore names for grpc_binary copy files

### DIFF
--- a/rules/grpcstar_binary.bzl
+++ b/rules/grpcstar_binary.bzl
@@ -74,14 +74,14 @@ def grpcstar_binary(**kwargs):
     native.genrule(
         name = starname,
         srcs = [main],
-        outs = [name + ".star"],
+        outs = [name + ".star_"],
         cmd = "cp $< $@",
     )
 
     native.genrule(
         name = dname,
         srcs = [descriptor],
-        outs = [name + ".descriptor"],
+        outs = [name + ".descriptor_"],
         cmd = "cp $< $@",
     )
 


### PR DESCRIPTION
This prevents a conflict if the end-user chooses a name like %{name}.star for their entrypoint file.